### PR TITLE
init conn abstract

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,51 @@
+name: Zig Test and Benchmark
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  ZIG_VERSION: 0.13.0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Zig
+        uses: actions/cache@v3
+        with:
+          path: ~/zig
+          key: ${{ runner.os }}-zig-${{ env.ZIG_VERSION }}
+
+      - name: Install Zig
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          wget https://ziglang.org/download/${{ env.ZIG_VERSION }}/zig-linux-x86_64-${{ env.ZIG_VERSION }}.tar.xz
+          tar -xf zig-linux-x86_64-${{ env.ZIG_VERSION }}.tar.xz
+          mv zig-linux-x86_64-${{ env.ZIG_VERSION }} ~/zig
+
+      - name: Add Zig to PATH
+        run: echo "${HOME}/zig" >> $GITHUB_PATH
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@v3
+        with:
+          path: |
+            zig-cache
+            ~/.cache/zig
+          key: ${{ runner.os }}-zig-build-${{ hashFiles('**/*.zig') }}
+          restore-keys: |
+            ${{ runner.os }}-zig-build-
+      - name: Formatting
+        run: zig fmt --check --color on .
+
+      - name: Unit testing
+        run: zig build test --summary all
+
+      - name: Building
+        run: zig build -Doptimize=ReleaseFast

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/go-yamux"]
+	path = deps/go-yamux
+	url = https://github.com/libp2p/go-yamux.git

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addStaticLibrary(.{
+        .name = "zig-yamux",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
+
+    const exe = b.addExecutable(.{
+        .name = "zig-yamux",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // Creates a step for unit testing. This only builds the test executable
+    // but does not run it.
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const exe_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,72 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "zig-yamux",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package. Only files listed here will remain on disk
+    // when using the zig package manager. As a rule of thumb, one should list
+    // files required for compilation plus any license(s).
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -5,6 +5,8 @@ const testing = std.testing;
 const net = std.net;
 const posix = std.posix;
 const Thread = std.Thread;
+const STDReadError = std.net.Stream.ReadError;
+const STDWriteError = std.net.Stream.WriteError;
 
 /// GenericConn provides a generic connection interface that implements read, write, and close methods
 /// It follows the pattern of GenericReader and GenericWriter in the standard library
@@ -116,151 +118,28 @@ pub const AnyConn = struct {
 };
 
 /// Adapter for std.net.Stream
-pub fn netStreamToConn(stream: std.net.Stream) GenericConn(
+pub fn stdStreamToConn(stream: std.net.Stream) GenericConn(
     std.net.Stream,
-    std.net.Stream.ReadError,
-    std.net.Stream.WriteError,
-    netStreamRead,
-    netStreamWrite,
-    netStreamClose,
+    STDReadError,
+    STDWriteError,
+    stdStreamRead,
+    stdStreamWrite,
+    stdStreamClose,
 ) {
     return .{ .context = stream };
 }
 
-fn netStreamRead(stream: std.net.Stream, buffer: []u8) std.net.Stream.ReadError!usize {
+fn stdStreamRead(stream: std.net.Stream, buffer: []u8) STDReadError!usize {
     return stream.read(buffer);
 }
 
-fn netStreamWrite(stream: std.net.Stream, buffer: []const u8) std.net.Stream.WriteError!usize {
+fn stdStreamWrite(stream: std.net.Stream, buffer: []const u8) STDWriteError!usize {
     return stream.write(buffer);
 }
 
-fn netStreamClose(stream: std.net.Stream) void {
+fn stdStreamClose(stream: std.net.Stream) void {
     stream.close();
 }
-
-// /// Shared structure for thread communication
-// const ServerContext = struct {
-//     address: net.Address,
-//     socket: posix.socket_t,
-//     should_exit: std.atomic.Value(bool),
-// };
-//
-// /// Echo server that uses an existing bound server
-// fn runEchoServer(context: *ServerContext) !void {
-//     while (!context.should_exit.load(.acquire)) {
-//         var client_addr: net.Address = undefined;
-//         var addr_len: posix.socklen_t = @sizeOf(net.Address);
-//
-//         const client_socket = posix.accept(
-//             context.socket,
-//             &client_addr.any,
-//             &addr_len,
-//             0,
-//         ) catch |err| {
-//             if (err == error.WouldBlock) {
-//                 std.time.sleep(10 * std.time.ns_per_ms);
-//                 continue;
-//             }
-//             return err;
-//         };
-//
-//         var client_stream = net.Stream{ .handle = client_socket };
-//         defer client_stream.close();
-//
-//         var buffer: [1024]u8 = undefined;
-//         while (true) {
-//             const bytes_read = client_stream.read(&buffer) catch break;
-//             if (bytes_read == 0) break; // Client closed connection
-//
-//             _ = client_stream.write(buffer[0..bytes_read]) catch break;
-//         }
-//     }
-// }
-//
-// test "GenericConn with std.net.Stream" {
-//     // Set up a TCP server on localhost with random port
-//     const localhost = try net.Address.parseIp("127.0.0.1", 0);
-//
-//     // Create a socket using posix API
-//     const sock = try posix.socket(
-//         localhost.any.family,
-//         posix.SOCK.STREAM,
-//         posix.IPPROTO.TCP
-//     );
-//
-//     // Enable address reuse
-//     try posix.setsockopt(
-//         sock,
-//         posix.SOL.SOCKET,
-//         posix.SO.REUSEADDR,
-//         &std.mem.toBytes(@as(c_int, 1))
-//     );
-//
-//     // Bind and listen
-//     try posix.bind(sock, &localhost.any, localhost.getOsSockLen());
-//     try posix.listen(sock, 128);
-//
-//     // Get the assigned local address
-//     var actual_addr: net.Address = undefined;
-//     var addr_len: posix.socklen_t = @sizeOf(net.Address);
-//     try posix.getsockname(sock, &actual_addr.any, &addr_len);
-//
-//     var server_context = ServerContext{
-//         .address = actual_addr,
-//         .socket = sock,
-//         .should_exit = std.atomic.Value(bool).init(false),
-//     };
-//
-//     // Start server in separate thread
-//     const server_thread = try Thread.spawn(.{}, runEchoServer, .{&server_context});
-//     defer {
-//         server_context.should_exit.store(true, .release);
-//         server_thread.join();
-//         posix.close(sock);
-//     }
-//
-//     // Client connection
-//     var client_stream = try net.tcpConnectToAddress(actual_addr);
-//     defer client_stream.close();
-//
-//     // Create GenericConn from std.net.Stream
-//     var generic_client = netStreamToConn(client_stream);
-//
-//     // Basic write/read test
-//     const test_message = "Hello, network stream!";
-//     const bytes_written = try generic_client.write(test_message);
-//     try testing.expectEqual(test_message.len, bytes_written);
-//
-//     // Read response
-//     var read_buffer: [128]u8 = undefined;
-//     const bytes_read = try generic_client.read(&read_buffer);
-//
-//     try testing.expectEqual(test_message.len, bytes_read);
-//     try testing.expectEqualStrings(test_message, read_buffer[0..bytes_read]);
-//
-//     // Test AnyConn conversion
-//     var any_client = generic_client.any();
-//     const any_message = "AnyConn test";
-//     _ = try any_client.write(any_message);
-//
-//     const any_read = try any_client.read(&read_buffer);
-//     try testing.expectEqual(any_message.len, any_read);
-//     try testing.expectEqualStrings(any_message, read_buffer[0..any_read]);
-//
-//     // Test reader/writer interface
-//     var reader = generic_client.reader();
-//     var writer = generic_client.writer();
-//
-//     try writer.writeAll("Line test\n");
-//
-//     var line_buffer: [20]u8 = undefined;
-//     const line = try reader.readUntilDelimiter(&line_buffer, '\n');
-//     try testing.expectEqualStrings("Line test", line);
-//
-//     // Clean up
-//     generic_client.close();
-// }
 
 /// Shared structure for thread communication
 const ServerContext = struct {
@@ -307,23 +186,17 @@ fn handleClient(client_socket: posix.socket_t) void {
 }
 
 test "GenericConn with std.net.Stream" {
-    // Set up a TCP server on localhost with random port
     const localhost = try net.Address.parseIp("127.0.0.1", 0);
 
-    // Create a socket using posix API
     const server_socket = try posix.socket(localhost.any.family, posix.SOCK.STREAM, posix.IPPROTO.TCP);
 
-    // Ensure socket is closed at the end
     defer posix.close(server_socket);
 
-    // Enable address reuse to avoid "address already in use" errors in tests
     try posix.setsockopt(server_socket, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
 
-    // Bind and listen
     try posix.bind(server_socket, &localhost.any, localhost.getOsSockLen());
     try posix.listen(server_socket, 128);
 
-    // Get the assigned local address
     var actual_addr: net.Address = undefined;
     var addr_len: posix.socklen_t = @sizeOf(net.Address);
     try posix.getsockname(server_socket, &actual_addr.any, &addr_len);
@@ -333,10 +206,8 @@ test "GenericConn with std.net.Stream" {
         .should_exit = std.atomic.Value(bool).init(false),
     };
 
-    // Start server in separate thread
     const server_thread = try Thread.spawn(.{}, runEchoServer, .{&server_context});
 
-    // Ensure server thread is stopped and joined at the end
     defer {
         // Signal thread to exit
         server_context.should_exit.store(true, .release);
@@ -346,27 +217,21 @@ test "GenericConn with std.net.Stream" {
         server_thread.join();
     }
 
-    // Create client connection - don't use defer close immediately
     var client_stream = try net.tcpConnectToAddress(actual_addr);
 
-    // Block to contain the test operations
     {
-        // Create GenericConn from std.net.Stream
-        var generic_client = netStreamToConn(client_stream);
+        var generic_client = stdStreamToConn(client_stream);
 
-        // Basic write/read test
         const test_message = "Hello, network stream!";
         const bytes_written = try generic_client.write(test_message);
         try testing.expectEqual(test_message.len, bytes_written);
 
-        // Read response
         var read_buffer: [128]u8 = undefined;
         const bytes_read = try generic_client.read(&read_buffer);
 
         try testing.expectEqual(test_message.len, bytes_read);
         try testing.expectEqualStrings(test_message, read_buffer[0..bytes_read]);
 
-        // Test AnyConn conversion
         var any_client = generic_client.any();
         const any_message = "AnyConn test";
         _ = try any_client.write(any_message);
@@ -375,7 +240,6 @@ test "GenericConn with std.net.Stream" {
         try testing.expectEqual(any_message.len, any_read);
         try testing.expectEqualStrings(any_message, read_buffer[0..any_read]);
 
-        // Test reader/writer interface
         var reader = generic_client.reader();
         var writer = generic_client.writer();
 
@@ -386,6 +250,5 @@ test "GenericConn with std.net.Stream" {
         try testing.expectEqualStrings("Line test", line);
     }
 
-    // Close client stream after all tests
     client_stream.close();
 }

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -1,0 +1,391 @@
+const std = @import("std");
+const mem = std.mem;
+const assert = std.debug.assert;
+const testing = std.testing;
+const net = std.net;
+const posix = std.posix;
+const Thread = std.Thread;
+
+/// GenericConn provides a generic connection interface that implements read, write, and close methods
+/// It follows the pattern of GenericReader and GenericWriter in the standard library
+pub fn GenericConn(
+    comptime Context: type,
+    comptime ReadE: type,
+    comptime WriteE: type,
+    comptime readFn: fn (context: Context, buffer: []u8) ReadE!usize,
+    comptime writeFn: fn (context: Context, buffer: []const u8) WriteE!usize,
+    comptime closeFn: fn (context: Context) void,
+) type {
+    return struct {
+        context: Context,
+
+        pub const ReadError = ReadE;
+        pub const WriteError = WriteE;
+
+        const Self = @This();
+
+        pub inline fn read(self: Self, buffer: []u8) ReadError!usize {
+            return readFn(self.context, buffer);
+        }
+
+        pub inline fn write(self: Self, buffer: []const u8) WriteError!usize {
+            return writeFn(self.context, buffer);
+        }
+
+        pub inline fn close(self: Self) void {
+            return closeFn(self.context);
+        }
+
+        pub inline fn reader(self: Self) std.io.GenericReader(
+            Context,
+            ReadError,
+            readFn,
+        ) {
+            return .{ .context = self.context };
+        }
+
+        pub inline fn writer(self: Self) std.io.GenericWriter(
+            Context,
+            WriteError,
+            writeFn,
+        ) {
+            return .{ .context = self.context };
+        }
+
+        pub inline fn any(self: *const Self) AnyConn {
+            return .{
+                .context = @ptrCast(&self.context),
+                .readFn = typeErasedReadFn,
+                .writeFn = typeErasedWriteFn,
+                .closeFn = typeErasedCloseFn,
+            };
+        }
+
+        fn typeErasedReadFn(context: *const anyopaque, buffer: []u8) anyerror!usize {
+            const ptr: *const Context = @alignCast(@ptrCast(context));
+            return readFn(ptr.*, buffer);
+        }
+
+        fn typeErasedWriteFn(context: *const anyopaque, buffer: []const u8) anyerror!usize {
+            const ptr: *const Context = @alignCast(@ptrCast(context));
+            return writeFn(ptr.*, buffer);
+        }
+
+        fn typeErasedCloseFn(context: *const anyopaque) void {
+            const ptr: *const Context = @alignCast(@ptrCast(context));
+            return closeFn(ptr.*);
+        }
+    };
+}
+
+/// AnyConn provides a type-erased interface for any connection that can read, write, and close
+pub const AnyConn = struct {
+    context: *const anyopaque,
+    readFn: *const fn (context: *const anyopaque, buffer: []u8) anyerror!usize,
+    writeFn: *const fn (context: *const anyopaque, buffer: []const u8) anyerror!usize,
+    closeFn: *const fn (context: *const anyopaque) void,
+
+    const Self = @This();
+    pub const Error = anyerror;
+
+    pub fn read(self: Self, buffer: []u8) Error!usize {
+        return self.readFn(self.context, buffer);
+    }
+
+    pub fn write(self: Self, buffer: []const u8) Error!usize {
+        return self.writeFn(self.context, buffer);
+    }
+
+    pub fn close(self: Self) Error!void {
+        return self.closeFn(self.context);
+    }
+
+    pub fn reader(self: Self) std.io.AnyReader {
+        return .{
+            .context = self.context,
+            .readFn = self.readFn,
+        };
+    }
+
+    pub fn writer(self: Self) std.io.AnyWriter {
+        return .{
+            .context = self.context,
+            .writeFn = self.writeFn,
+        };
+    }
+};
+
+/// Adapter for std.net.Stream
+pub fn netStreamToConn(stream: std.net.Stream) GenericConn(
+    std.net.Stream,
+    std.net.Stream.ReadError,
+    std.net.Stream.WriteError,
+    netStreamRead,
+    netStreamWrite,
+    netStreamClose,
+) {
+    return .{ .context = stream };
+}
+
+fn netStreamRead(stream: std.net.Stream, buffer: []u8) std.net.Stream.ReadError!usize {
+    return stream.read(buffer);
+}
+
+fn netStreamWrite(stream: std.net.Stream, buffer: []const u8) std.net.Stream.WriteError!usize {
+    return stream.write(buffer);
+}
+
+fn netStreamClose(stream: std.net.Stream) void {
+    stream.close();
+}
+
+// /// Shared structure for thread communication
+// const ServerContext = struct {
+//     address: net.Address,
+//     socket: posix.socket_t,
+//     should_exit: std.atomic.Value(bool),
+// };
+//
+// /// Echo server that uses an existing bound server
+// fn runEchoServer(context: *ServerContext) !void {
+//     while (!context.should_exit.load(.acquire)) {
+//         var client_addr: net.Address = undefined;
+//         var addr_len: posix.socklen_t = @sizeOf(net.Address);
+//
+//         const client_socket = posix.accept(
+//             context.socket,
+//             &client_addr.any,
+//             &addr_len,
+//             0,
+//         ) catch |err| {
+//             if (err == error.WouldBlock) {
+//                 std.time.sleep(10 * std.time.ns_per_ms);
+//                 continue;
+//             }
+//             return err;
+//         };
+//
+//         var client_stream = net.Stream{ .handle = client_socket };
+//         defer client_stream.close();
+//
+//         var buffer: [1024]u8 = undefined;
+//         while (true) {
+//             const bytes_read = client_stream.read(&buffer) catch break;
+//             if (bytes_read == 0) break; // Client closed connection
+//
+//             _ = client_stream.write(buffer[0..bytes_read]) catch break;
+//         }
+//     }
+// }
+//
+// test "GenericConn with std.net.Stream" {
+//     // Set up a TCP server on localhost with random port
+//     const localhost = try net.Address.parseIp("127.0.0.1", 0);
+//
+//     // Create a socket using posix API
+//     const sock = try posix.socket(
+//         localhost.any.family,
+//         posix.SOCK.STREAM,
+//         posix.IPPROTO.TCP
+//     );
+//
+//     // Enable address reuse
+//     try posix.setsockopt(
+//         sock,
+//         posix.SOL.SOCKET,
+//         posix.SO.REUSEADDR,
+//         &std.mem.toBytes(@as(c_int, 1))
+//     );
+//
+//     // Bind and listen
+//     try posix.bind(sock, &localhost.any, localhost.getOsSockLen());
+//     try posix.listen(sock, 128);
+//
+//     // Get the assigned local address
+//     var actual_addr: net.Address = undefined;
+//     var addr_len: posix.socklen_t = @sizeOf(net.Address);
+//     try posix.getsockname(sock, &actual_addr.any, &addr_len);
+//
+//     var server_context = ServerContext{
+//         .address = actual_addr,
+//         .socket = sock,
+//         .should_exit = std.atomic.Value(bool).init(false),
+//     };
+//
+//     // Start server in separate thread
+//     const server_thread = try Thread.spawn(.{}, runEchoServer, .{&server_context});
+//     defer {
+//         server_context.should_exit.store(true, .release);
+//         server_thread.join();
+//         posix.close(sock);
+//     }
+//
+//     // Client connection
+//     var client_stream = try net.tcpConnectToAddress(actual_addr);
+//     defer client_stream.close();
+//
+//     // Create GenericConn from std.net.Stream
+//     var generic_client = netStreamToConn(client_stream);
+//
+//     // Basic write/read test
+//     const test_message = "Hello, network stream!";
+//     const bytes_written = try generic_client.write(test_message);
+//     try testing.expectEqual(test_message.len, bytes_written);
+//
+//     // Read response
+//     var read_buffer: [128]u8 = undefined;
+//     const bytes_read = try generic_client.read(&read_buffer);
+//
+//     try testing.expectEqual(test_message.len, bytes_read);
+//     try testing.expectEqualStrings(test_message, read_buffer[0..bytes_read]);
+//
+//     // Test AnyConn conversion
+//     var any_client = generic_client.any();
+//     const any_message = "AnyConn test";
+//     _ = try any_client.write(any_message);
+//
+//     const any_read = try any_client.read(&read_buffer);
+//     try testing.expectEqual(any_message.len, any_read);
+//     try testing.expectEqualStrings(any_message, read_buffer[0..any_read]);
+//
+//     // Test reader/writer interface
+//     var reader = generic_client.reader();
+//     var writer = generic_client.writer();
+//
+//     try writer.writeAll("Line test\n");
+//
+//     var line_buffer: [20]u8 = undefined;
+//     const line = try reader.readUntilDelimiter(&line_buffer, '\n');
+//     try testing.expectEqualStrings("Line test", line);
+//
+//     // Clean up
+//     generic_client.close();
+// }
+
+/// Shared structure for thread communication
+const ServerContext = struct {
+    socket: posix.socket_t,
+    should_exit: std.atomic.Value(bool),
+};
+
+/// Echo server that uses an existing bound server socket
+fn runEchoServer(context: *ServerContext) !void {
+    while (!context.should_exit.load(.acquire)) {
+        var client_addr: net.Address = undefined;
+        var addr_len: posix.socklen_t = @sizeOf(net.Address);
+
+        const client_socket = posix.accept(
+            context.socket,
+            &client_addr.any,
+            &addr_len,
+            0,
+        ) catch |err| {
+            if (err == error.WouldBlock) {
+                std.time.sleep(10 * std.time.ns_per_ms);
+                continue;
+            }
+            if (context.should_exit.load(.acquire)) return;
+            return err;
+        };
+
+        // Handle client in same thread for simplicity
+        handleClient(client_socket);
+    }
+}
+
+fn handleClient(client_socket: posix.socket_t) void {
+    var client_stream = net.Stream{ .handle = client_socket };
+    defer client_stream.close(); // This will close the socket safely
+
+    var buffer: [1024]u8 = undefined;
+    while (true) {
+        const bytes_read = client_stream.read(&buffer) catch break;
+        if (bytes_read == 0) break; // Client closed connection
+
+        _ = client_stream.write(buffer[0..bytes_read]) catch break;
+    }
+}
+
+test "GenericConn with std.net.Stream" {
+    // Set up a TCP server on localhost with random port
+    const localhost = try net.Address.parseIp("127.0.0.1", 0);
+
+    // Create a socket using posix API
+    const server_socket = try posix.socket(localhost.any.family, posix.SOCK.STREAM, posix.IPPROTO.TCP);
+
+    // Ensure socket is closed at the end
+    defer posix.close(server_socket);
+
+    // Enable address reuse to avoid "address already in use" errors in tests
+    try posix.setsockopt(server_socket, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
+
+    // Bind and listen
+    try posix.bind(server_socket, &localhost.any, localhost.getOsSockLen());
+    try posix.listen(server_socket, 128);
+
+    // Get the assigned local address
+    var actual_addr: net.Address = undefined;
+    var addr_len: posix.socklen_t = @sizeOf(net.Address);
+    try posix.getsockname(server_socket, &actual_addr.any, &addr_len);
+
+    var server_context = ServerContext{
+        .socket = server_socket,
+        .should_exit = std.atomic.Value(bool).init(false),
+    };
+
+    // Start server in separate thread
+    const server_thread = try Thread.spawn(.{}, runEchoServer, .{&server_context});
+
+    // Ensure server thread is stopped and joined at the end
+    defer {
+        // Signal thread to exit
+        server_context.should_exit.store(true, .release);
+        // Allow time for the thread to notice
+        std.time.sleep(10 * std.time.ns_per_ms);
+        // Join thread
+        server_thread.join();
+    }
+
+    // Create client connection - don't use defer close immediately
+    var client_stream = try net.tcpConnectToAddress(actual_addr);
+
+    // Block to contain the test operations
+    {
+        // Create GenericConn from std.net.Stream
+        var generic_client = netStreamToConn(client_stream);
+
+        // Basic write/read test
+        const test_message = "Hello, network stream!";
+        const bytes_written = try generic_client.write(test_message);
+        try testing.expectEqual(test_message.len, bytes_written);
+
+        // Read response
+        var read_buffer: [128]u8 = undefined;
+        const bytes_read = try generic_client.read(&read_buffer);
+
+        try testing.expectEqual(test_message.len, bytes_read);
+        try testing.expectEqualStrings(test_message, read_buffer[0..bytes_read]);
+
+        // Test AnyConn conversion
+        var any_client = generic_client.any();
+        const any_message = "AnyConn test";
+        _ = try any_client.write(any_message);
+
+        const any_read = try any_client.read(&read_buffer);
+        try testing.expectEqual(any_message.len, any_read);
+        try testing.expectEqualStrings(any_message, read_buffer[0..any_read]);
+
+        // Test reader/writer interface
+        var reader = generic_client.reader();
+        var writer = generic_client.writer();
+
+        try writer.writeAll("Line test\n");
+
+        var line_buffer: [20]u8 = undefined;
+        const line = try reader.readUntilDelimiter(&line_buffer, '\n');
+        try testing.expectEqualStrings("Line test", line);
+    }
+
+    // Close client stream after all tests
+    client_stream.close();
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+pub fn main() !void {
+    // Prints to stderr (it's a shortcut based on `std.io.getStdErr()`)
+    std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
+
+    // stdout is for the actual output of your application, for example if you
+    // are implementing gzip, then only the compressed bytes should be sent to
+    // stdout, not any debugging messages.
+    const stdout_file = std.io.getStdOut().writer();
+    var bw = std.io.bufferedWriter(stdout_file);
+    const stdout = bw.writer();
+
+    try stdout.print("Run `zig build test` to run the tests.\n", .{});
+
+    try bw.flush(); // don't forget to flush!
+}
+
+test "simple test" {
+    var list = std.ArrayList(i32).init(std.testing.allocator);
+    defer list.deinit(); // try commenting this out and see if zig detects the memory leak!
+    try list.append(42);
+    try std.testing.expectEqual(@as(i32, 42), list.pop());
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub const conn = @import("conn.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}


### PR DESCRIPTION
Fix #2 .

This pull request introduces an implementation of a generic connection interface. It add `go-libp2p` submodule for spec and reference implementation.

### Dependency Management:
* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R3): Added a submodule for the `go-yamux` dependency.
* [`deps/go-yamux`](diffhunk://#diff-c7526cb722b1f356dda955257a2eee7f39e18a58b95e24bf757b3876a2c163b5R1): Added the submodule commit for `go-yamux`.

### Generic Connection Interface:
* [`src/conn.zig`](diffhunk://#diff-a22d02ca9e982286817be2a04007c07cb9204d516968f295e0166243b3d348c0R1-R391): Implemented a generic connection interface (`GenericConn`) and a type-erased connection interface (`AnyConn`), along with an adapter for `std.net.Stream` and a test for the generic connection with `std.net.Stream`.
